### PR TITLE
Feature/about page

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the About controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,2 +1,4 @@
 class AboutController < ApplicationController
+  def index
+  end
 end

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,0 +1,2 @@
+class AboutController < ApplicationController
+end

--- a/app/helpers/about_helper.rb
+++ b/app/helpers/about_helper.rb
@@ -1,0 +1,2 @@
+module AboutHelper
+end

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,0 +1,5 @@
+<h1>About Us</h1>
+
+<div>
+  <p>To plant a garden is to believe in tomorrow!</p>
+</div>

--- a/app/views/layouts/_top_nav.html.erb
+++ b/app/views/layouts/_top_nav.html.erb
@@ -22,6 +22,9 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+      <li class="nav-item end-0">
+      <%= link_to about_index_path, class: "nav-link " do %> About Us<% end %>
+      </li>
         <%# <li class="nav-item dropdown">
           <a
             class="nav-link dropdown-toggle"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     <ul class="nav justify-content-center border-bottom pb-3 mb-3">
       <li class="nav-item"><a href="#" class="nav-link px-2 text-muted">FAQ</a></li>
       <li class="nav-item"><a href="#" class="nav-link px-2 text-muted">Help</a></li>
-      <li class="nav-item"><a href="#" class="nav-link px-2 text-muted">About</a></li>
+      <li class="nav-item"><a href="about" class="nav-link px-2 text-muted">About</a></li>
     </ul>
     <p class="text-center text-muted">© 2021 Jungle, Inc</p>
   </footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
 
+  get 'about/index'
   root to: 'products#index'
 
+  resources :about, only: [:index]
   resources :products, only: [:index, :show]
   resources :categories, only: [:show]
 

--- a/spec/helpers/about_helper_spec.rb
+++ b/spec/helpers/about_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AboutHelper. For example:
+#
+# describe AboutHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AboutHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/about_spec.rb
+++ b/spec/requests/about_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Abouts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
The owners have requested that we add an about page to the website.

The page should be accessible via /about and it should be linked in the bottom nav as "About Us".

The page can just contain static content that describes the store. Details about what goes into the content are unclear and unimportant for now. Feel free to get creative here.

